### PR TITLE
move videos from a local file to the Camera Roll

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In Javascript, you can do something like this:
 ```javascript
 
 // Quickly save a base-64 encoded data uri to the cameraroll.
-CamerRoll.saveToCameraRoll(base64String, function() {
+CameraRoll.saveToCameraRoll(base64String, function() {
 }, function(err) {
 });
 
@@ -43,8 +43,22 @@ CameraRoll.getPhotos(function(photo) {
   // This callback will be called for each photo in the roll. It's async, yo!
 });
 
+// Copy a video file from a local URL to the camera roll
+CameraRoll.moveVideoToCameraRoll(fileUrl, function() {
+}, function(err) {
+});
+
 ```
 
+Notes
+-----
+
+Moving a video to the camera roll can be useful in the case that an app downloads a video from a 
+remote URL using the FileTransfer plugin, but you would like the user to have access to the video
+in his or her camera roll for later viewing.
+
+`CameraRoll.moveVideoToCameraRoll` uses the `ALAssetsLibrary` framework which has been deprecated 
+in iOS 9.0. It works for now, but should probably be re-written using the `Photos` framework.
 
 TODO
 -----

--- a/src/ios/IonicCameraRoll.h
+++ b/src/ios/IonicCameraRoll.h
@@ -8,5 +8,6 @@
 
 - (void)getPhotos:(CDVInvokedUrlCommand*)command;
 - (void)saveToCameraRoll:(CDVInvokedUrlCommand*)command;
+- (void)moveVideoToCameraRoll:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/IonicCameraRoll.m
+++ b/src/ios/IonicCameraRoll.m
@@ -39,6 +39,30 @@
   CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"saved"];
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
+
+- (void)moveVideoToCameraRoll:(CDVInvokedUrlCommand*)command
+{
+    //TODO use the Photos framework instead
+    NSLog(@"IonicCameraRoll moving file to camera roll...");
+
+    NSString* sourceUrl = [command.arguments objectAtIndex:0];
+
+    NSURL *movieUrl = [NSURL URLWithString:sourceUrl];
+
+    ALAssetsLibrary *library = [[ALAssetsLibrary alloc] init];
+    [library writeVideoAtPathToSavedPhotosAlbum:movieUrl completionBlock:^(NSURL *assetURL, NSError *error){
+        if(error) {
+            NSLog(@"IonicCameraRoll: Error on saving movie : %@", error);
+            CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[error description]];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        }
+        else {
+            NSLog(@"URL: %@", assetURL);
+            CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"saved"];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        }
+    }];
+}
 /**
  * Get all the photos in the library.
  *

--- a/www/CameraRoll.js
+++ b/www/CameraRoll.js
@@ -10,4 +10,8 @@ cameraRoll.saveToCameraRoll = function(imageBase64, successCallback, errorCallba
   exec(successCallback, errorCallback, "CameraRoll", "saveToCameraRoll", [imageBase64]);
 };
 
+cameraRoll.moveVideoToCameraRoll = function(videoUrl, successCallback, errorCallback, options) {
+    exec(successCallback, errorCallback, "CameraRoll", "moveVideoToCameraRoll", [videoUrl]);
+};
+
 module.exports = cameraRoll;


### PR DESCRIPTION
Moving a video to the camera roll can be useful in the case that an app downloads a video from a remote URL using the FileTransfer plugin, but you would like the user to have access to the video in his or her camera roll for later viewing.

`CameraRoll.moveVideoToCameraRoll` uses the `ALAssetsLibrary` framework which has been deprecated in iOS 9.0. It works for now, but should probably be re-written using the `Photos` framework.